### PR TITLE
Replace hardcoded endpoint selection with protocol matching

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -13,4 +13,5 @@ pub trait ChatDataBase: Send + Sync {
     fn get_messages_filtered(&mut self);
     fn add_message(&mut self, msg: ChatMessage);
     fn mark_as(&mut self, uuid: &String, intent: MarkIntent) -> Option<ChatMessage>;
+    fn get_all_messages(&self) -> Vec<ChatMessage>;
 }

--- a/src/db/simple_vec.rs
+++ b/src/db/simple_vec.rs
@@ -24,6 +24,10 @@ impl ChatDataBase for SimpleVecDB {
         self.messages.push(msg);
     }
 
+    fn get_all_messages(&self) -> Vec<ChatMessage> {
+        self.messages.clone()
+    }
+
     fn mark_as(&mut self, uuid: &String, intent: super::MarkIntent) -> Option<ChatMessage> {
         for message in &mut self.messages {
             if message.uuid == *uuid {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use dtchat_backend::{
     message::{ChatMessage, MessageStatus},
 };
 use socket_engine::{
-    endpoint::Endpoint,
+    endpoint::{Endpoint},
     engine::Engine,
     event::{ConnectionEvent, DataEvent},
 };


### PR DESCRIPTION
# Description 

## Main Issue
Before: The code used hardcoded `self.localpeer.endpoints[0].clone()` for endpoint selection, which could cause protocol mismatches (e.g., trying to send TCP data through UDP endpoint).

### Added Smart Protocol Matching
- `find_local_endpoint_for_protocol(endpoint)` matches TCP→TCP, UDP→UDP, BP→BP
- Fallback to first endpoint only when no protocol match found

### Enhanced Message Management:
- Added `get_all_messages()` method to database interface and implementations
- Enables retrieval of complete message history for UI display or analysis
- Added `network_endpoint` field to `ChatMessage` for protocol awareness
- Implemented protocol-based message filtering capabilities
